### PR TITLE
Warn on large DMS wind angles

### DIFF
--- a/docs/src/model_selection.md
+++ b/docs/src/model_selection.md
@@ -13,6 +13,13 @@ Use DMS when:
 - the turbine is represented as stacked independent vertical slices;
 - the requested fidelity is consistent with streamtube assumptions.
 
+DMS emits a diagnostic warning when `windangle` approaches cross-flow. The
+solver rotates the freestream into the turbine frame, but downstream streamtube
+pairing for near-90-degree direction changes is not yet physically validated.
+For large direction-change load studies, rotate the input frame into the
+dominant wind direction or use a higher-fidelity model with a matching
+validation basis.
+
 ## Actuator Cylinder
 
 Set `AeroModel = "AC"` for the actuator-cylinder path. The implementation is based on the BYU FLOW Lab VAWT AC method and has been adapted for OWENS slice and turbine workflows.

--- a/src/DMS.jl
+++ b/src/DMS.jl
@@ -8,7 +8,8 @@ import Statistics
 import Statistics: mean
 
 _dms_number_type(x::Number) = typeof(x)
-_dms_number_type(x::AbstractArray) = isempty(x) ? eltype(x) : mapreduce(typeof, promote_type, x)
+_dms_number_type(x::AbstractArray) =
+    isempty(x) ? eltype(x) : mapreduce(typeof, promote_type, x)
 _dms_number_type(x) = typeof(x)
 
 function _dms_output_type(turbine, env, a_in)
@@ -30,6 +31,24 @@ function _dms_output_type(turbine, env, a_in)
         _dms_number_type(env.speed_of_sound),
         _dms_number_type(a_in),
     )
+end
+
+const DMS_WINDANGLE_DIAGNOSTIC_LIMIT_RAD = 75.0 * pi / 180.0
+
+function _warn_if_large_dms_windangle(windangle)
+    angle = try
+        Float64(windangle)
+    catch
+        return nothing
+    end
+    isfinite(angle) || return nothing
+
+    if abs(sin(angle)) >= sin(DMS_WINDANGLE_DIAGNOSTIC_LIMIT_RAD)
+        @warn "DMS windangle is near cross-flow; downstream streamtube pairing is not validated for this condition. Consider rotating the input frame or using AC/OLAF for large direction-change studies." windangle_degrees =
+            angle * 180 / pi maxlog = 1
+    end
+
+    return nothing
 end
 
 """
@@ -297,6 +316,7 @@ function DMS(
     ntheta = turbine.ntheta
     #Convert global F.O.R. winds to turbine frame
     windangle = env.windangle
+    _warn_if_large_dms_windangle(windangle)
 
     V_xtemp = env.V_x .* cos(windangle) + env.V_y .* sin(windangle) # Vinf is V_x, t is for turbine direction f.o.r.
     V_ytemp = -env.V_x .* sin(windangle) + env.V_y .* cos(windangle)

--- a/test/dms_unit_tests.jl
+++ b/test/dms_unit_tests.jl
@@ -237,3 +237,44 @@ end
     @test rotated[7] ≈ baseline[7] atol=1e-14
     @test rotated[12] ≈ baseline[12] atol=1e-14
 end
+
+@testset "DMS large wind-angle diagnostic" begin
+    @test OWENSAero._warn_if_large_dms_windangle("invalid") === nothing
+    @test OWENSAero._warn_if_large_dms_windangle(NaN) === nothing
+    @test OWENSAero._warn_if_large_dms_windangle(30.0 * pi / 180.0) === nothing
+
+    ntheta = 8
+    af(alpha, Re, M) = (2.0 * alpha, 0.01 + alpha^2)
+    windangle = 80.0 * pi / 180.0
+    freestream = 5.0
+    turbine = OWENSAero.Turbine(
+        1.5,
+        fill(1.5, ntheta),
+        1.0,
+        fill(0.2, ntheta),
+        fill(0.1, ntheta),
+        fill(0.05, ntheta),
+        fill(2.0, ntheta),
+        2,
+        af,
+        ntheta,
+        false,
+    )
+    env = OWENSAero.Environment(
+        1.225,
+        1.7894e-5,
+        fill(freestream * cos(windangle), ntheta),
+        fill(freestream * sin(windangle), ntheta),
+        zeros(ntheta),
+        zeros(ntheta),
+        windangle,
+        "none",
+        "DMS",
+        zeros(2 * ntheta),
+    )
+
+    @test_logs(
+        (:warn, r"DMS windangle is near cross-flow"),
+        OWENSAero.DMS(turbine, env; w = zeros(2 * ntheta), solve = false),
+    )
+end


### PR DESCRIPTION
## Summary
- warn when DMS is run near cross-flow wind angles where downstream streamtube pairing is not physically validated
- document the DMS wind-angle diagnostic in model selection docs
- add a regression test for the warning path

## Tests
- julia --project=. test/dms_unit_tests.jl
- julia --project=. test/api_unit_tests.jl
- git diff --check

Closes #17