### PR TITLE
Add DMS tower-shadow hook

### DIFF
--- a/docs/src/model_selection.md
+++ b/docs/src/model_selection.md
@@ -96,7 +96,7 @@ Model option strings are normalized at construction and setup time: `BV`/`boeing
 
 ## Tower Shadow Scope
 
-`towerShadowVelocity(velocity, relative_position; active=false, ...)` provides a pinned, off-by-default inflow-deficit primitive for tower shadow studies. The active model applies a Gaussian downstream velocity deficit in the supplied wind frame. It is intentionally not coupled into DMS or AC induction yet; callers must explicitly use the returned velocity in their own load-building workflow until a validated solver-integrated tower-shadow option is added.
+`towerShadowVelocity(velocity, relative_position; active=false, ...)` provides a pinned, off-by-default inflow-deficit primitive for tower shadow studies. The active model applies a Gaussian downstream velocity deficit in the supplied wind frame. DMS also accepts `tower_shadow = (tower_radius = ..., wake_expansion = ..., centerline_deficit = ...)` to apply that primitive before the streamtube solve. This DMS hook is opt-in and is intended for validation development; AC integration and end-to-end OWENS structural mapping remain open work.
 
 ## Lifting Strut Scope
 

--- a/src/DMS.jl
+++ b/src/DMS.jl
@@ -51,6 +51,41 @@ function _warn_if_large_dms_windangle(windangle)
     return nothing
 end
 
+_dms_radius_at(turbine, idx) = length(turbine.r) > 1 ? turbine.r[idx] : turbine.r
+
+function _apply_dms_tower_shadow(V_x, V_y, thetavec, turbine, tower_shadow)
+    tower_shadow === nothing && return V_x, V_y
+    tower_shadow isa NamedTuple || throw(
+        ArgumentError(
+            "tower_shadow must be nothing or a NamedTuple of towerShadowVelocity keyword arguments",
+        ),
+    )
+
+    active = get(tower_shadow, :active, true)
+    tower_radius = get(tower_shadow, :tower_radius, 0.0)
+    wake_expansion = get(tower_shadow, :wake_expansion, 0.0)
+    centerline_deficit = get(tower_shadow, :centerline_deficit, 0.0)
+
+    shadowed_V_x = similar(V_x)
+    shadowed_V_y = similar(V_y)
+    for idx in eachindex(thetavec)
+        radius = _dms_radius_at(turbine, idx)
+        relative_position = [radius * cos(thetavec[idx]), radius * sin(thetavec[idx])]
+        velocity = towerShadowVelocity(
+            [V_x[idx], V_y[idx]],
+            relative_position;
+            active,
+            tower_radius,
+            wake_expansion,
+            centerline_deficit,
+        )
+        shadowed_V_x[idx] = velocity[1]
+        shadowed_V_y[idx] = velocity[2]
+    end
+
+    return shadowed_V_x, shadowed_V_y
+end
+
 """
 INTERNAL streamtube(a,theta,turbine,env;output_all=false,Vxwake=nothing,solvestep=false)
 
@@ -301,7 +336,10 @@ Double multiple streamtube model.
 `finite_span_factor` may be a nonnegative scalar or length-`ntheta` vector. It
 defaults to `1.0` and scales aerodynamic blade loads, torque, thrust, induction
 source terms, and aerodynamic moment without scaling added mass, buoyancy, or
-centrifugal terms.
+centrifugal terms. `tower_shadow` may be `nothing` or a named tuple of
+`towerShadowVelocity` keyword arguments; when present, DMS applies the
+off-by-default tower-shadow velocity primitive in the turbine frame before the
+streamtube solve.
 """
 function DMS(
     turbine,
@@ -310,16 +348,23 @@ function DMS(
     idx_RPI = 1:turbine.ntheta,
     solve = true,
     finite_span_factor = 1.0,
+    tower_shadow = nothing,
 )
     #TODO: Inputs documentation
     a_in = w
     ntheta = turbine.ntheta
+    dtheta = 2 * pi / (ntheta)
+    # thetavec = collect(dtheta/2:dtheta:2*pi-dtheta/2)
+    thetavec = collect((dtheta/2):dtheta:(2*pi))
+
     #Convert global F.O.R. winds to turbine frame
     windangle = env.windangle
     _warn_if_large_dms_windangle(windangle)
 
     V_xtemp = env.V_x .* cos(windangle) + env.V_y .* sin(windangle) # Vinf is V_x, t is for turbine direction f.o.r.
     V_ytemp = -env.V_x .* sin(windangle) + env.V_y .* cos(windangle)
+    V_xtemp, V_ytemp =
+        _apply_dms_tower_shadow(V_xtemp, V_ytemp, thetavec, turbine, tower_shadow)
     env_turbine = Environment(
         env.rho,
         env.mu,
@@ -352,10 +397,7 @@ function DMS(
 
     # Unpack the rest
 
-    dtheta = 2 * pi / (ntheta)
     finite_span_factor = _validated_finite_span_factor(finite_span_factor, ntheta)
-    # thetavec = collect(dtheta/2:dtheta:2*pi-dtheta/2)
-    thetavec = collect((dtheta/2):dtheta:(2*pi))
 
     astar = zeros(Real, ntheta * 2)#env.aw_warm[1:ntheta] #zeros(ntheta)
 

--- a/src/OWENSAero.jl
+++ b/src/OWENSAero.jl
@@ -312,8 +312,11 @@ function _validated_speed_of_sound(speed_of_sound)
         throw(ArgumentError("speed_of_sound must be a finite positive real value"))
     isfinite(speed_of_sound) ||
         throw(ArgumentError("speed_of_sound must be finite; got $(repr(speed_of_sound))"))
-    speed_of_sound > zero(speed_of_sound) ||
-        throw(ArgumentError("speed_of_sound must be greater than zero; got $(repr(speed_of_sound))"))
+    speed_of_sound > zero(speed_of_sound) || throw(
+        ArgumentError(
+            "speed_of_sound must be greater than zero; got $(repr(speed_of_sound))",
+        ),
+    )
     return speed_of_sound
 end
 
@@ -328,7 +331,7 @@ Environment(
     DynamicStallModel,
     AeroModel,
     aw_warm,
-;
+    ;
     speed_of_sound = 343.0,
 ) = Environment(
     rho,
@@ -375,7 +378,7 @@ Environment(
     AddedMass_Coeff_Ca,
     centrifugal_force_flag,
     aw_warm,
-;
+    ;
     speed_of_sound = 343.0,
 ) = Environment(
     rho,
@@ -406,47 +409,40 @@ Environment(
     [0.0, 0.0, -9.81],
     _validated_speed_of_sound(speed_of_sound),
 )
-Environment(
-    rho,
-    mu,
-    V_x,
-    DynamicStallModel,
-    AeroModel,
-    aw_warm;
-    speed_of_sound = 343.0,
-) = Environment(
-    rho,
-    mu,
-    V_x,
-    zeros(Real, size(V_x)),
-    zeros(Real, size(V_x)),
-    zeros(Real, size(V_x)),
-    0.0,
-    _canonical_dynamic_stall_model(DynamicStallModel),
-    _canonical_aero_model(AeroModel),
-    false,
-    false,
-    false,
-    1.0,
-    false,
-    aw_warm,
-    zeros(Int, 1),
-    zeros(Int, length(V_x)),
-    deepcopy(V_x),
-    zeros(Int, length(V_x)),
-    zeros(Int, length(V_x)),
-    zeros(Real, length(V_x)),
-    LeishmanBeddoesState(length(V_x)),
-    false,
-    zeros(Real, length(V_x)),
-    zeros(Real, length(V_x)),
-    [0.0, 0.0, -9.81],
-    _validated_speed_of_sound(speed_of_sound),
-)
+Environment(rho, mu, V_x, DynamicStallModel, AeroModel, aw_warm; speed_of_sound = 343.0) =
+    Environment(
+        rho,
+        mu,
+        V_x,
+        zeros(Real, size(V_x)),
+        zeros(Real, size(V_x)),
+        zeros(Real, size(V_x)),
+        0.0,
+        _canonical_dynamic_stall_model(DynamicStallModel),
+        _canonical_aero_model(AeroModel),
+        false,
+        false,
+        false,
+        1.0,
+        false,
+        aw_warm,
+        zeros(Int, 1),
+        zeros(Int, length(V_x)),
+        deepcopy(V_x),
+        zeros(Int, length(V_x)),
+        zeros(Int, length(V_x)),
+        zeros(Real, length(V_x)),
+        LeishmanBeddoesState(length(V_x)),
+        false,
+        zeros(Real, length(V_x)),
+        zeros(Real, length(V_x)),
+        [0.0, 0.0, -9.81],
+        _validated_speed_of_sound(speed_of_sound),
+    )
 
 # TODO: This is a silly hack that should be removed once `envslices` isn't a global variable
 # anymore but instead instantiated with the correct types from the start.
-function prepare_for_duals(::Type{DT}) where DT
+function prepare_for_duals(::Type{DT}) where {DT}
     global envslices
     function convert_env(env)
         env′ = Environment(
@@ -474,7 +470,7 @@ function prepare_for_duals(::Type{DT}) where DT
             env.suction,
             env.accel_flap,
             env.accel_edge,
-            env.gravity
+            env.gravity,
         )
         return env′
     end
@@ -947,6 +943,7 @@ Calculates steady state aerodynamics for a single VAWT slice
 * `solve::Bool`: Optional, False is used when you want the model outputs for a given set of induction factors without resolving them.
 * `ifw::Bool`: Optional, used to tell the Vinf lookup to attempt to use the dynamic inflow wind library, requires preprocessing as is shown in the test cases.
 * `finite_span_factor::Union{Real,AbstractVector}`: Optional caller-supplied finite-span scaling factor. It must be a finite nonnegative scalar or length-`ntheta` vector and scales aerodynamic blade loads, induction source terms, torque, thrust, and pitching moment without scaling added mass, buoyancy, or centrifugal terms.
+* `tower_shadow::Union{Nothing,NamedTuple}`: Optional DMS-only tower-shadow velocity hook. Pass a named tuple of `towerShadowVelocity` keyword arguments to apply the tower-shadow primitive before solving streamtubes.
 
 
 # Outputs:
@@ -975,10 +972,16 @@ function steady(
     solve = true,
     ifw = false,
     finite_span_factor = 1.0,
+    tower_shadow = nothing,
 )
     if env.AeroModel=="DMS"
-        return DMS(turbine, env; w, idx_RPI, solve, finite_span_factor)
+        return DMS(turbine, env; w, idx_RPI, solve, finite_span_factor, tower_shadow)
     elseif env.AeroModel=="AC"
+        tower_shadow === nothing || throw(
+            ArgumentError(
+                "tower_shadow is currently implemented for the DMS steady path only",
+            ),
+        )
         turbines = Array{OWENSAero.Turbine}(undef, 1)
         turbines[1] = turbine
         return AC(turbines, env; w, idx_RPI, solve, ifw, finite_span_factor)

--- a/test/dms_unit_tests.jl
+++ b/test/dms_unit_tests.jl
@@ -278,3 +278,65 @@ end
         OWENSAero.DMS(turbine, env; w = zeros(2 * ntheta), solve = false),
     )
 end
+
+@testset "DMS tower-shadow hook" begin
+    ntheta = 8
+    af(alpha, Re, M) = (2.0 * alpha, 0.01 + alpha^2)
+    turbine = OWENSAero.Turbine(
+        1.5,
+        fill(1.5, ntheta),
+        1.0,
+        fill(0.2, ntheta),
+        fill(0.1, ntheta),
+        fill(0.05, ntheta),
+        fill(2.0, ntheta),
+        2,
+        af,
+        ntheta,
+        false,
+    )
+    env = OWENSAero.Environment(
+        1.225,
+        1.7894e-5,
+        fill(5.0, ntheta),
+        zeros(ntheta),
+        zeros(ntheta),
+        zeros(ntheta),
+        0.0,
+        "none",
+        "DMS",
+        zeros(2 * ntheta),
+    )
+
+    baseline = OWENSAero.DMS(turbine, env; w = zeros(2 * ntheta), solve = false)
+    shadowed = OWENSAero.DMS(
+        turbine,
+        env;
+        w = zeros(2 * ntheta),
+        solve = false,
+        tower_shadow = (tower_radius = 2.0, wake_expansion = 0.0, centerline_deficit = 0.5),
+    )
+
+    @test env.V_x == fill(5.0, ntheta)
+    @test env.V_y == zeros(ntheta)
+    @test shadowed[7][1] < baseline[7][1]
+    @test shadowed[7][2] < baseline[7][2]
+    @test shadowed[7][4] ≈ baseline[7][4] atol=1e-14
+    @test shadowed[7][5] ≈ baseline[7][5] atol=1e-14
+    @test shadowed[1] != baseline[1]
+
+    @test_throws ArgumentError OWENSAero.DMS(
+        turbine,
+        env;
+        w = zeros(2 * ntheta),
+        solve = false,
+        tower_shadow = (tower_radius = -1.0, centerline_deficit = 0.5),
+    )
+    @test_throws ArgumentError OWENSAero.DMS(
+        turbine,
+        env;
+        w = zeros(2 * ntheta),
+        solve = false,
+        tower_shadow = true,
+    )
+end


### PR DESCRIPTION
## Summary
- add an opt-in DMS tower_shadow keyword that applies the existing towerShadowVelocity primitive before streamtube solves
- document the current DMS-only scope while leaving AC and end-to-end OWENS coupling as open work
- add a DMS regression test covering velocity reduction, unchanged caller environment, and invalid tower_shadow inputs

## Tests
- julia --project=. test/dms_unit_tests.jl
- julia --project=. test/api_unit_tests.jl
- git diff --check

Refs #19