### PR TITLE
Expand OWENSAero developer documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,6 +15,7 @@ makedocs(;
         "Rigid HAWT CCBlade Example" => "hawt_ccblade_example.md",
         "Frames, Units, and Outputs" => joinpath("theory", "frames_units.md"),
         "Validation and Testing" => "validation.md",
+        "Developer Guide" => "developer_guide.md",
         "API Reference" => joinpath("reference", "reference.md"),
     ],
     sitename = "OWENSAero.jl",

--- a/docs/src/developer_guide.md
+++ b/docs/src/developer_guide.md
@@ -1,0 +1,64 @@
+# Developer Guide
+
+This guide is for changes to OWENSAero models, examples, tests, and docs. Most
+public workflows are stateful and feed coupled structural simulations, so small
+changes should be reviewed for numerical and physical consistency.
+
+## Local Workflow
+
+Use the tests and examples together:
+
+| Area | Primary files |
+|:---|:---|
+| Direct DMS/AC slices | `test/simple_example.jl`, `test/dms_unit_tests.jl` |
+| Full turbine lifecycle | `test/full_turb.jl`, `test/full_turb_undersampling.jl` |
+| Dynamic stall | `test/dyn_stall_tests.jl`, `examples/dynamic_stall` |
+| HAWT adapter | `test/hawt_example_tests.jl`, `examples/HAWT/rigid_ccblade_hawt.jl` |
+| AeroDyn readers | `test/api_unit_tests.jl`, `src/AeroDynInputs.jl` |
+
+Run focused tests while developing, then run the package test suite before
+opening a PR:
+
+```sh
+julia --project=. test/runtests.jl
+```
+
+Build docs from the package root:
+
+```sh
+julia --project=docs docs/make.jl
+```
+
+## Model Changes
+
+Before changing DMS, AC, or full-turbine code, check:
+
+| Topic | Review point |
+|:---|:---|
+| Units | Keep all public inputs and outputs in SI units. Angles are radians unless a name explicitly carries `_d`. |
+| Frames | Document any change to radial, tangential, vertical, blade, hub, or global load directions. |
+| Signs | Check torque, `CP`, tangential force, wind-angle rotation, clockwise/counter-clockwise cases, and pitching moments independently. |
+| State | Reinitialize with `setupTurb` when topology, airfoil tables, inflow source, or discretization changes. |
+| Tuple contracts | Update tests and docs when steady or unsteady output tuple order changes. |
+| Interpolation | Keep airfoil interpolation inside validated tabular bounds unless the extrapolation behavior is explicitly tested. |
+| AD | Add derivative checks for branches expected to support optimization. |
+
+## Test Expectations
+
+Tests should pin concrete values, not just finite or nonzero results. For a new
+branch, include at least one output-shape assertion, one force or moment value,
+one local velocity or angle-of-attack value, and one coefficient or state value.
+
+For coupled OWENS-facing changes, test the transformed load channel as well as
+the local aerodynamic value. This catches sign and ordering mistakes that are
+invisible in aggregate power.
+
+When adding examples, keep generated output out of git unless the file is a
+small reviewed fixture needed by a deterministic test.
+
+## Documentation
+
+Docs should describe the model that exists in the current checkout. If a page
+mentions a validation case, point to the test or example that exercises it.
+Public docstrings should name mutation, state ownership, units, and output
+ordering whenever those details matter for coupled simulations.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -13,6 +13,10 @@ The package contains two primary VAWT aerodynamic paths:
 
 Both paths share the `Turbine`, `Environment`, and `UnsteadyParams` data structures. The high-level turbine workflow in `setupTurb`, `steadyTurb`, and `advanceTurb` builds one or more vertical slices, stores model state, and returns distributed aerodynamic loads for coupling to OWENS structural dynamics.
 
+For horizontal-axis verification work, OWENSAero also includes a CCBlade-based
+adapter used by the AeroDyn Basic HAWT tests. That path follows AeroDyn station
+conventions rather than the VAWT slice workflow.
+
 ## Documentation Map
 
 - [Quickstart](quickstart.md) shows the smallest direct slice and full-turbine calls.
@@ -20,6 +24,9 @@ Both paths share the `Turbine`, `Environment`, and `UnsteadyParams` data structu
 - [Full Turbine Workflow](full_turbine_workflow.md) documents the stateful `setupTurb`/`steadyTurb`/`advanceTurb` path used by coupled OWENS runs.
 - [Dynamic Stall](dynamic_stall.md) documents the Boeing-Vertol test/example path.
 - [RM2 Example](rm2_example.md) points to the standalone RM2 aerodynamic example.
+- [AeroDyn Input Readers](aerodyn_inputs.md) documents the AeroDyn blade and polar file readers.
+- [Rigid HAWT CCBlade Example](hawt_ccblade_example.md) documents the Basic HAWT BEM verification workflow.
 - [Frames, Units, and Outputs](theory/frames_units.md) records load directions and expected SI units.
 - [Validation and Testing](validation.md) identifies the tests that currently pin model behavior and the remaining validation gaps.
+- [Developer Guide](developer_guide.md) gives the review checklist for aerodynamic model changes, tests, examples, and documentation.
 - [API Reference](reference/reference.md) is the generated function and type index.

--- a/docs/src/reference/reference.md
+++ b/docs/src/reference/reference.md
@@ -2,6 +2,22 @@
 CurrentModule = OWENSAero
 ```
 
+# API Reference
+
+The pages before this one describe lifecycle, model selection, and validation
+expectations. Use this page for exact exported names and docstrings.
+
+## Exported Groups
+
+| Group | Representative API |
+|:---|:---|
+| Core data | `Turbine`, `Environment`, `UnsteadyParams`, `AdvanceTurbineOutput` |
+| Direct models | `DMS`, `AC`, `Unsteady_Step` |
+| Full turbine | `setupTurb`, `steadyTurb`, `advanceTurb`, `deformTurb` |
+| Dynamic stall | Boeing-Vertol and Leishman-Beddoes helpers |
+| HAWT adapter | CCBlade/AeroDyn Basic HAWT helper functions |
+| Readers | AeroDyn blade and polar input readers |
+
 ## Index
 
 ```@index


### PR DESCRIPTION
Summary:
- adds a developer guide for aerodynamic model, lifecycle, validation, and documentation changes
- updates docs navigation and home page coverage of HAWT verification workflows
- expands API reference context around exported groups and lifecycle docs

Verification:
- julia --project=docs docs/make.jl passed
- git diff --check -- docs/make.jl docs/src passed