### PR TITLE
Add AeroDyn reader guardrails

### DIFF
--- a/docs/src/hawt_ccblade_example.md
+++ b/docs/src/hawt_ccblade_example.md
@@ -49,6 +49,26 @@ the blade-root offset, drops the zero-span root station, and compares interior
 station `Alpha`, `Cl`, `Cd`, `Cx`, `Cy`, `Fxp`, and `-Fyp` channels against the
 CCBlade solve.
 
+## AeroDyn comparison guardrails
+
+`readAeroDynDriverFile` resolves relative `AeroFile` and `InflowFile` paths from
+the driver file's directory unless a different `base_directory` is supplied.
+This is pinned for nested driver paths, including paths with spaces.
+
+For multi-turbine driver files, pass `turbine_index` explicitly. The reader then
+selects `NumBlades(i)`, `RotSpeed(i)`, `BldPitch(i_j)`, and
+`BldHubRad_bl(i_j)` from that turbine and rejects out-of-range indices. The
+CCBlade bridge uses the selected turbine metadata and, by default, the largest
+selected `BldHubRad_bl` as the BEM hub radius.
+
+Keep `root_station_policy` visible in validation scripts. The default
+`:drop_zero_span` policy removes AeroDyn's common zero-span root station before
+building CCBlade sections; `:strict_positive` instead requires every blade
+station to be positive. Drag-in-induction settings and torque/power signs also
+need explicit normalization before comparing to OpenFAST output channels, so the
+current bridge is a reproducible input path, not yet an OpenFAST validation
+baseline.
+
 The Oye state update uses the steady CCBlade axial induction as the
 quasi-steady input. This keeps the future dynamic-inflow coupling explicit:
 the HAWT solver must own induction state, time constants, and load mapping

--- a/docs/src/theory/frames_units.md
+++ b/docs/src/theory/frames_units.md
@@ -39,6 +39,8 @@ DMS computes `CP` from the signed torque history `Q`, not `abs(Q)`. Negative tor
 
 Airfoil reader functions expect angle-of-attack and coefficient tables compatible with the selected model. Tables may include a fourth `Cm25` column. The readers keep the older `cl, cd = af(alpha, Re, Mach)` call pattern intact, and `af(alpha, Re, Mach; return_cm=true)` returns `cl`, `cd`, and `Cm25`. For DMS and AC, `Mach` is computed from the local relative speed divided by `Environment.speed_of_sound`; set this keyword when constructing `Environment` for water, temperature-sensitive air cases, or validation data with a specified sound speed.
 
+The AeroDyn-format readers preserve the historical out-of-range interpolation behavior by default with `extrapolation=:legacy`. Validation cases and optimization studies that should fail fast on unsupported polar queries can build callbacks with `extrapolation=:error`, which throws when angle of attack is outside the lookup table and, for multi-Reynolds-number tables, when Reynolds number is outside the tabulated range. Single-Reynolds-number tables keep the existing Reynolds-insensitive semantics.
+
 DMS and AC convert `Cm25` to a distributed section moment with `M25 = Cm25 * q * chord^2`, where `q = 0.5 * rho * Vloc^2`. That moment is returned with the aerodynamic loads for coupled OWENS runs. If a user-supplied airfoil function only returns `cl, cd`, OWENSAero uses `Cm25 = 0.0`.
 
 The dynamic-stall path carries additional state for prior angle of attack and Boeing-Vertol flags. Because these state variables affect transient loads, unsteady tests should pin the full output vector for a named input file and time history.

--- a/src/vawt-ac/src/airfoilread.jl
+++ b/src/vawt-ac/src/airfoilread.jl
@@ -6,7 +6,43 @@
 import FLOWMath
 import Interpolations
 
+const _AIRFOIL_EXTRAPOLATION_POLICIES = (:legacy, :error)
+
 _parse_airfoil_header_number(line) = parse(Float64, split(strip(line))[end])
+
+function _validate_airfoil_extrapolation_policy(extrapolation)
+    extrapolation isa Symbol ||
+        throw(ArgumentError("airfoil extrapolation policy must be a Symbol; got $(repr(extrapolation))"))
+    extrapolation in _AIRFOIL_EXTRAPOLATION_POLICIES ||
+        throw(ArgumentError("unsupported airfoil extrapolation policy $(repr(extrapolation)); supported policies are :legacy and :error"))
+    return extrapolation
+end
+
+function _check_airfoil_alpha_bounds(alphain, alpha_min, alpha_max, extrapolation, filename)
+    extrapolation === :legacy && return nothing
+    isfinite(alphain) ||
+        throw(ArgumentError("airfoil angle of attack must be finite; got $(repr(alphain))"))
+    if alphain < alpha_min || alphain > alpha_max
+        throw(ArgumentError(
+            "airfoil angle of attack $(alphain) rad is outside the tabulated range " *
+            "[$(alpha_min), $(alpha_max)] rad for $(repr(filename))",
+        ))
+    end
+    return nothing
+end
+
+function _check_airfoil_reynolds_bounds(Re, Re_min, Re_max, extrapolation, filename)
+    extrapolation === :legacy && return nothing
+    isfinite(Re) ||
+        throw(ArgumentError("airfoil Reynolds number must be finite; got $(repr(Re))"))
+    if Re < Re_min || Re > Re_max
+        throw(ArgumentError(
+            "airfoil Reynolds number $(Re) is outside the tabulated range " *
+            "[$(Re_min), $(Re_max)] for $(repr(filename))",
+        ))
+    end
+    return nothing
+end
 
 function _read_first_reynolds_airfoil_table(filename)
     alpha = Float64[]
@@ -65,25 +101,30 @@ function _read_first_reynolds_airfoil_table(filename)
 end
 
 """
-    readaerodyn(filename)
+    readaerodyn(filename; extrapolation = :legacy)
 
 create airfoil lookup for the first Reynolds-number table in an OWENSAero
 airfoil file
 
 # Inputs
 * `filename::string`: file path/name to airfoil file formatted like in the test folder
+* `extrapolation::Symbol`: `:legacy` preserves historical out-of-range
+  interpolation/extrapolation; `:error` throws if alpha is outside the table.
 
 # Outputs:
 * `af::function`: cl, cd = af(alpha,re,mach) with alpha in rad. Use
   `af(alpha,re,mach; return_cm=true)` to also return Cm25.
 
 """
-function readaerodyn(filename)
+function readaerodyn(filename; extrapolation = :legacy)
+    extrapolation = _validate_airfoil_extrapolation_policy(extrapolation)
     table = _read_first_reynolds_airfoil_table(filename)
     alpha = table.alpha
     cl = table.cl
     cd = table.cd
     cm = table.cm
+    alpha_min = minimum(alpha) * pi / 180
+    alpha_max = maximum(alpha) * pi / 180
 
     # af = AirfoilData(alpha*pi/180.0, cl, cd)
 
@@ -97,6 +138,7 @@ function readaerodyn(filename)
     afcm = FLOWMath.Akima(alpha*pi/180, cm)
 
     function af(alphain,re,mach; return_cm=false)
+        _check_airfoil_alpha_bounds(alphain, alpha_min, alpha_max, extrapolation, filename)
         # if alphain>maximum(alpha)*pi/180 || alphain<minimum(alpha)*pi/180
         #     @error "aoa is greater or less than what is defined"
         # end
@@ -111,24 +153,29 @@ function readaerodyn(filename)
 end
 
 """
-    readaerodyn_BV(filename)
+    readaerodyn_BV(filename; extrapolation = :legacy)
 
 create airfoil lookup function with Boeing-Vertol dynamic stall metadata from
 the first Reynolds-number table in an OWENSAero airfoil file
 
 # Inputs
 * `filename::string`: file path/name to airfoil file formatted like in the test folder
+* `extrapolation::Symbol`: `:legacy` preserves historical out-of-range
+  interpolation/extrapolation; `:error` throws if alpha is outside the table.
 
 # Outputs:
 * `af::function`: cl, cd = af_BV(alpha,Re,M,env,V_twist,c,dt,U;solvestep=false) with alpha in rad, OWENSAero.Env, V_twist in rad/s, c chord in m, dt in sec, U Vloc in m/s, solvestep true during solve loop. Use `return_cm=true` to also return Cm25.
 
 """
-function readaerodyn_BV(filename) #TODO: use multiple dispatch to simplify this
+function readaerodyn_BV(filename; extrapolation = :legacy) #TODO: use multiple dispatch to simplify this
+    extrapolation = _validate_airfoil_extrapolation_policy(extrapolation)
     table = _read_first_reynolds_airfoil_table(filename)
     alpha = table.alpha
     cl = table.cl
     cd = table.cd
     cm = table.cm
+    alpha_min = minimum(alpha) * pi / 180
+    alpha_max = maximum(alpha) * pi / 180
 
     # af = AirfoilData(alpha*pi/180.0, cl, cd)
 
@@ -142,6 +189,7 @@ function readaerodyn_BV(filename) #TODO: use multiple dispatch to simplify this
     afcm = FLOWMath.Akima(alpha*pi/180, cm)
     cl=0.0
     function af(alphain,Re,umach,family_factor)
+        _check_airfoil_alpha_bounds(alphain, alpha_min, alpha_max, extrapolation, filename)
         if alphain>maximum(alpha)*pi/180 || alphain<minimum(alpha)*pi/180
             @error "aoa is greater or less than what is defined"
         end
@@ -159,6 +207,7 @@ function readaerodyn_BV(filename) #TODO: use multiple dispatch to simplify this
     tc = table.thickness_to_chord
 
     function af_BV(alpha,Re,M,env,V_twist,c,dt,U;solvestep=false,idx=1,return_cm=false)
+        _check_airfoil_alpha_bounds(alpha, alpha_min, alpha_max, extrapolation, filename)
         if idx==1
             idxmin1 = length(env.alpha_last)
         else
@@ -179,20 +228,24 @@ function readaerodyn_BV(filename) #TODO: use multiple dispatch to simplify this
 end
 
 """
-    readaerodyn_BV_NEW(filename;DynamicStallModel="BV")
+    readaerodyn_BV_NEW(filename; DynamicStallModel = "BV", extrapolation = :legacy)
 
 for a file with multiple reynolds numbers create airfoil lookup function with boeing vertol dynamic stall model and wrap interpolation
 
 # Inputs
 * `filename::string`: file path/name to airfoil file formatted like in the test folder
 * `DynamicStallModel::string`: "BV", "LB", or "none"
+* `extrapolation::Symbol`: `:legacy` preserves historical out-of-range
+  interpolation/extrapolation; `:error` throws if alpha is outside the lookup
+  grid and, for multi-Re tables, if Re is outside the tabulated range.
 
 # Outputs:
 * `af::function`: cl, cd = af_BV(alpha,Re,M,env,V_twist,c,dt,U;solvestep=false) with alpha in rad, OWENSAero.Env, V_twist in rad/s, c chord in m, dt in sec, U Vloc in m/s, solvestep true during solve loop. Use `return_cm=true` to also return Cm25.
 * `af::function`: cl, cd = af(alpha,re,mach) with alpha in rad. Use `return_cm=true` to also return Cm25.
 """
-function readaerodyn_BV_NEW(filename;DynamicStallModel="BV") #TODO: use multiple dispatch to simplify this
+function readaerodyn_BV_NEW(filename;DynamicStallModel="BV", extrapolation = :legacy) #TODO: use multiple dispatch to simplify this
     DynamicStallModel = _canonical_dynamic_stall_model(DynamicStallModel)
+    extrapolation = _validate_airfoil_extrapolation_policy(extrapolation)
 
     # Loop through the file and determine how many Reynolds numbers there are
     nRe = 0
@@ -206,6 +259,8 @@ function readaerodyn_BV_NEW(filename;DynamicStallModel="BV") #TODO: use multiple
 
     # Set up arrays
     alphas = [collect(-180:1:-21);collect(-20:0.5:20);collect(21:1:180)].*pi/180
+    alpha_min = minimum(alphas)
+    alpha_max = maximum(alphas)
     cls = zeros(length(alphas),nRe)
     cds = zeros(length(alphas),nRe)
     cms = zeros(length(alphas),nRe)
@@ -265,7 +320,11 @@ function readaerodyn_BV_NEW(filename;DynamicStallModel="BV") #TODO: use multiple
 
     if nRe == 0
         throw(ArgumentError("No Reynolds-number airfoil tables were found in $(repr(filename))."))
-    elseif nRe == 1
+    end
+    Re_min = minimum(REs)
+    Re_max = maximum(REs)
+
+    if nRe == 1
         itpcl = Interpolations.interpolate((alphas,), cls[:,1], Interpolations.Gridded(Interpolations.Linear()))
         cl_alpha = Interpolations.extrapolate(itpcl, Interpolations.Flat())
 
@@ -305,6 +364,10 @@ function readaerodyn_BV_NEW(filename;DynamicStallModel="BV") #TODO: use multiple
 
     # Create the base airfoil wrapper function
     function af2(alpha,Re,umach=0.0,family_factor=1.0; return_cm=false)
+        _check_airfoil_alpha_bounds(alpha, alpha_min, alpha_max, extrapolation, filename)
+        if nRe > 1
+            _check_airfoil_reynolds_bounds(Re, Re_min, Re_max, extrapolation, filename)
+        end
 
         # if length(REs)>1
             # cl = Dierckx.evaluate(clspl,alpha, Re)
@@ -328,6 +391,10 @@ function readaerodyn_BV_NEW(filename;DynamicStallModel="BV") #TODO: use multiple
         af2(alpha, Re, umach, family_factor; return_cm=true)
 
     function af_BV2(alpha,Re,M,env,V_twist,c,dt,U;solvestep=false,idx=1,return_cm=false)
+        _check_airfoil_alpha_bounds(alpha, alpha_min, alpha_max, extrapolation, filename)
+        if nRe > 1
+            _check_airfoil_reynolds_bounds(Re, Re_min, Re_max, extrapolation, filename)
+        end
         if idx==1
             idxmin1 = length(env.alpha_last)
         else
@@ -352,6 +419,10 @@ function readaerodyn_BV_NEW(filename;DynamicStallModel="BV") #TODO: use multiple
     end
 
     function af_LB2(alpha,Re,M,env,V_twist,c,dt,U;solvestep=false,idx=1,return_cm=false)
+        _check_airfoil_alpha_bounds(alpha, alpha_min, alpha_max, extrapolation, filename)
+        if nRe > 1
+            _check_airfoil_reynolds_bounds(Re, Re_min, Re_max, extrapolation, filename)
+        end
         idxmin1 = idx == 1 ? length(env.lb_state.cl_ref_last) : idx - 1
         U_safe = FLOWMath.ksmax([U, 0.001])
         ds = 2.0 * U_safe * dt / c

--- a/test/api_unit_tests.jl
+++ b/test/api_unit_tests.jl
@@ -641,6 +641,82 @@ end
         @test driver_result.CT ≈ solve_result.CT atol=1e-15
         @test driver_result.CQ ≈ solve_result.CQ atol=1e-15
 
+        nested_driver_dir = joinpath(tmpdir, "nested driver case with spaces")
+        mkpath(nested_driver_dir)
+        multi_driver_path = joinpath(nested_driver_dir, "two turbine hawt driver.dvr")
+        write(
+            multi_driver_path,
+            """
+            True           Echo
+                      1    AnalysisType
+                    0.5    TMax
+                   0.01    DT
+            "../solve_primary.dat"     AeroFile
+                  1.225    FldDens
+            1.460734693877551E-05     KinVisc
+                    335    SpdSound
+                      1    CompInflow
+            "../ifw_primary.dat"       InflowFile
+                     10    HWindSpeed
+                    200    RefHt
+                      0    PLExp
+                      2    NumTurbines
+            False         BasicHAWTFormat(1)
+            True          HAWTprojection(1)
+                      2   NumBlades(1)
+                    0.5   BldHubRad_bl(1_1)
+                    0.5   BldHubRad_bl(1_2)
+                      0   RotMotionType(1)
+                   10.0   RotSpeed(1)
+                      0   BldMotionType(1)
+                    5.0   BldPitch(1_1)
+                    5.0   BldPitch(1_2)
+            False         BasicHAWTFormat(2)
+            True          HAWTprojection(2)
+                      3   NumBlades(2)
+                    1.0   BldHubRad_bl(2_1)
+                    1.0   BldHubRad_bl(2_2)
+                    1.0   BldHubRad_bl(2_3)
+                      0   RotMotionType(2)
+            19.09859317102744 RotSpeed(2)
+                      0   BldMotionType(2)
+                    1.0   BldPitch(2_1)
+                    1.0   BldPitch(2_2)
+                    1.0   BldPitch(2_3)
+                    2.0   VTKHubRad
+            """,
+        )
+        selected_driver = OWENSAero.readAeroDynDriverFile(
+            multi_driver_path;
+            turbine_index = 2,
+        )
+        @test selected_driver.base_directory == nested_driver_dir
+        @test selected_driver.aero_file == solve_primary_path
+        @test selected_driver.inflow_file == inflow_path
+        @test selected_driver.num_turbines == 2
+        @test selected_driver.turbine_index == 2
+        @test selected_driver.num_blades == 3
+        @test selected_driver.rot_speed_rpm ≈ 19.09859317102744 atol=1e-14
+        @test selected_driver.rotor_speed_rad_per_s ≈ 2.0 atol=1e-15
+        @test selected_driver.blade_pitch_deg == [1.0, 1.0, 1.0]
+        @test selected_driver.blade_hub_radius == [1.0, 1.0, 1.0]
+
+        selected_result = OWENSAero.ccbladeHAWTSolveFromAeroDynDriver(
+            multi_driver_path;
+            turbine_index = 2,
+            tip_radius = 7.0,
+            npts = 8,
+        )
+        @test selected_result.aerodyn_driver_file == multi_driver_path
+        @test selected_result.driver_hub_radius_used == 1.0
+        @test selected_result.aerodyn_driver.turbine_index == 2
+        @test selected_result.thrust ≈ solve_result.thrust atol=1e-10
+        @test selected_result.torque ≈ solve_result.torque atol=1e-10
+        @test selected_result.power ≈ solve_result.power atol=1e-10
+        @test selected_result.CP ≈ solve_result.CP atol=1e-15
+        @test selected_result.CT ≈ solve_result.CT atol=1e-15
+        @test selected_result.CQ ≈ solve_result.CQ atol=1e-15
+
         steady_driver_path = joinpath(tmpdir, "steady_driver.dvr")
         write(
             steady_driver_path,
@@ -690,6 +766,41 @@ end
             driver_path;
             base_directory = tmpdir,
             turbine_index = 2,
+        )
+
+        transient_driver_path = joinpath(tmpdir, "transient_driver.dvr")
+        write(
+            transient_driver_path,
+            replace(read(driver_path, String), "1    AnalysisType" => "2    AnalysisType"),
+        )
+        @test_throws ArgumentError OWENSAero.readAeroDynDriverFile(
+            transient_driver_path;
+            base_directory = tmpdir,
+        )
+
+        unsupported_comp_inflow_path = joinpath(tmpdir, "unsupported_comp_inflow.dvr")
+        write(
+            unsupported_comp_inflow_path,
+            replace(read(driver_path, String), "1    CompInflow" => "2    CompInflow"),
+        )
+        @test_throws ArgumentError OWENSAero.readAeroDynDriverFile(
+            unsupported_comp_inflow_path;
+            base_directory = tmpdir,
+        )
+
+        stopped_driver_path = joinpath(tmpdir, "stopped_driver.dvr")
+        write(
+            stopped_driver_path,
+            replace(
+                read(driver_path, String),
+                "19.09859317102744 RotSpeed(1)" => "0.0 RotSpeed(1)",
+            ),
+        )
+        @test_throws ArgumentError OWENSAero.ccbladeHAWTSolveFromAeroDynDriver(
+            stopped_driver_path;
+            base_directory = tmpdir,
+            tip_radius = 7.0,
+            npts = 8,
         )
 
         @test_throws ArgumentError OWENSAero.aeroDynHAWTCCBladeInputs(
@@ -2862,6 +2973,7 @@ end
 
 @testset "AeroDyn airfoil readers" begin
     filename = joinpath(API_TEST_DIR, "airfoils", "NACA_0015_RE3E5.dat")
+    multire_filename = joinpath(API_TEST_DIR, "airfoils", "NACA_0015.dat")
 
     af = OWENSAero.readaerodyn(filename)
     cl0, cd0 = af(0.0, 3.0e5, 0.0)
@@ -2875,11 +2987,40 @@ end
     @test clm5 ≈ -0.55 atol=1e-14
     @test cdm5 ≈ 0.0114 atol=1e-14
 
+    af_strict = OWENSAero.readaerodyn(filename; extrapolation = :error)
+    cl_strict, cd_strict, cm_strict =
+        af_strict(5 * pi / 180, 3.0e5, 0.0; return_cm = true)
+    @test cl_strict ≈ 0.55 atol=1e-14
+    @test cd_strict ≈ 0.0114 atol=1e-14
+    @test cm_strict == 0.0
+    @test_throws ArgumentError af_strict(181 * pi / 180, 3.0e5, 0.0)
+    @test_throws ArgumentError OWENSAero.readaerodyn(filename; extrapolation = :flat)
+    @test_throws ArgumentError OWENSAero.readaerodyn(filename; extrapolation = "error")
+
     af_new_static = OWENSAero.readaerodyn_BV_NEW(filename; DynamicStallModel = "NONE")
     cl_new, cd_new, cm_new = af_new_static(5 * pi / 180, 3.0e5, 0.0; return_cm = true)
     @test cl_new ≈ 0.55 atol=1e-14
     @test cd_new ≈ 0.0114 atol=1e-14
     @test cm_new == 0.0
+
+    af_new_static_strict =
+        OWENSAero.readaerodyn_BV_NEW(filename; DynamicStallModel = "NONE", extrapolation = :error)
+    cl_new_strict, cd_new_strict =
+        af_new_static_strict(5 * pi / 180, 1.0e2, 0.0)
+    @test cl_new_strict ≈ 0.55 atol=1e-14
+    @test cd_new_strict ≈ 0.0114 atol=1e-14
+    @test_throws ArgumentError af_new_static_strict(181 * pi / 180, 3.0e5, 0.0)
+
+    af_new_multire_strict = OWENSAero.readaerodyn_BV_NEW(
+        multire_filename;
+        DynamicStallModel = "NONE",
+        extrapolation = :error,
+    )
+    cl_multire_strict, cd_multire_strict =
+        af_new_multire_strict(5 * pi / 180, 3.6e5, 0.0)
+    @test cl_multire_strict ≈ 0.55 atol=1e-14
+    @test cd_multire_strict ≈ 0.0114 atol=1e-14
+    @test_throws ArgumentError af_new_multire_strict(5 * pi / 180, 1.0, 0.0)
 
     af_lb = OWENSAero.readaerodyn_BV_NEW(filename; DynamicStallModel = "LB")
     env_lb = OWENSAero.Environment(
@@ -2958,6 +3099,34 @@ end
     @test env.alpha_last[2] ≈ 5 * pi / 180 atol=1e-14
     @test env.BV_DynamicFlagL[2] == 0
     @test env.BV_DynamicFlagD[2] == 0
+
+    af_bv_strict = OWENSAero.readaerodyn_BV(filename; extrapolation = :error)
+    strict_env = OWENSAero.Environment(
+        1.225,
+        1.7894e-5,
+        fill(5.0, 4),
+        zeros(4),
+        zeros(4),
+        zeros(4),
+        0.0,
+        "BV",
+        "DMS",
+        zeros(8),
+    )
+    @test_throws ArgumentError af_bv_strict(
+        181 * pi / 180,
+        3.0e5,
+        0.0,
+        strict_env,
+        0.0,
+        0.2,
+        0.1,
+        5.0;
+        idx = 2,
+    )
+    @test strict_env.alpha_last[2] == 0.0
+    @test strict_env.BV_DynamicFlagL[2] == 0
+    @test strict_env.BV_DynamicFlagD[2] == 0
 
     stall_env = OWENSAero.Environment(
         1.225,


### PR DESCRIPTION
## Summary
- add strict AeroDyn polar extrapolation guards for alpha/Re bounds
- document HAWT AeroDyn comparison constraints
- add API tests for HAWT guardrails and airfoil reader bounds

## Verification
- julia --project=. test/api_unit_tests.jl
- git diff --check origin/master..HEAD